### PR TITLE
Добавлена заглушка Vite манифеста для тестов

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ RPG Forum — веб‑платформа для обсуждения ролев
 - `npm run build` — production‑сборка фронтенда.
 - `npm run dev` — дев‑сервер Vite.
 
+При запуске тестов заглушка Vite‑манифеста создаётся автоматически: скрипт `tests/bootstrap.php` генерирует файл `public/build/manifest.json` с фиктивными путями к ассетам, чтобы Blade‑шаблоны не падали в тестовой среде.
+
 ## Системные акторы
 
 Миграция `create_actors_core` добавляет таблицы `actors`, `actor_memberships` и `scene_actors`, а также поля `actor_id` и `posted_by_user_id` в таблицу `posts`.

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
+         bootstrap="tests/bootstrap.php"
          colors="true"
 >
     <testsuites>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$buildDir = __DIR__ . '/../public/build';
+
+if (! is_dir($buildDir)) {
+    mkdir($buildDir, 0755, true);
+}
+
+$manifestPath = $buildDir . '/manifest.json';
+
+if (! file_exists($manifestPath)) {
+    $manifest = [];
+
+    // Основные точки входа
+    if (file_exists(__DIR__ . '/../resources/js/app.tsx')) {
+        $manifest['resources/js/app.tsx'] = [
+            'file' => 'assets/app.js',
+            'src' => 'resources/js/app.tsx',
+            'isEntry' => true,
+        ];
+    } elseif (file_exists(__DIR__ . '/../resources/js/app.js')) {
+        $manifest['resources/js/app.js'] = [
+            'file' => 'assets/app.js',
+            'src' => 'resources/js/app.js',
+            'isEntry' => true,
+        ];
+    }
+
+    if (file_exists(__DIR__ . '/../resources/css/app.css')) {
+        $manifest['resources/css/app.css'] = [
+            'file' => 'assets/app.css',
+            'src' => 'resources/css/app.css',
+        ];
+    }
+
+    // Страницы Inertia
+    $pagesDir = __DIR__ . '/../resources/js/pages';
+    if (is_dir($pagesDir)) {
+        $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($pagesDir));
+        foreach ($iterator as $file) {
+            if ($file->isFile() && $file->getExtension() === 'tsx') {
+                $relative = 'resources/js/pages/' . str_replace('\\', '/', $iterator->getSubPathName());
+                $manifest[$relative] = [
+                    'file' => 'assets/' . $file->getBasename('.tsx') . '.js',
+                    'src' => $relative,
+                ];
+            }
+        }
+    }
+
+    file_put_contents(
+        $manifestPath,
+        json_encode($manifest, JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT)
+    );
+}
+


### PR DESCRIPTION
## Изменения
- настроен bootstrap тестов с генерацией минимального Vite манифеста
- phpunit теперь использует общий bootstrap
- описание поведения добавлено в документацию

## Проверка
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68a223816a448328a98f2994bc5a9a1c